### PR TITLE
fix(build): update LuaJIT source and replace lseek64/off64_t for musl compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM alpine:latest AS builder
 
 LABEL maintainer="Thomas Jammet <contact@monaserver.ovh>"
 
-ENV LUAJIT_VERSION 2.1.0-beta3
-ENV LUAJIT_DOWNLOAD_SHA256 1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3
+ENV LUAJIT_VERSION 2.1.ROLLING
+ENV LUAJIT_DOWNLOAD_SHA256 31d7a4853df4c548bf91c13d3b690d19663d4c06ae952b62606c8225d0b410ad
 
 # install prerequisites
 RUN apk add --no-cache libgcc \
@@ -21,7 +21,7 @@ RUN apk add --no-cache --virtual .build-deps \
 
 # Build & install luajit
 WORKDIR /usr/src
-RUN curl -fSL -o luajit.tar.gz http://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz \
+RUN curl -fSL -o luajit.tar.gz https://github.com/LuaJIT/LuaJIT/archive/refs/tags/v$LUAJIT_VERSION.tar.gz \
 	&& echo "$LUAJIT_DOWNLOAD_SHA256 *luajit.tar.gz" | sha256sum -c \
 	&& tar -xzf luajit.tar.gz \
 	&& cd LuaJIT-$LUAJIT_VERSION \
@@ -31,6 +31,7 @@ RUN curl -fSL -o luajit.tar.gz http://luajit.org/download/LuaJIT-$LUAJIT_VERSION
 
 # Build
 RUN git clone https://github.com/MonaSolutions/MonaServer2.git
+RUN find MonaServer2 -type f \( -name "*.cpp" -o -name "*.h" \) -exec sed -i 's/lseek64/lseek/g; s/off64_t/off_t/g' {} +
 WORKDIR /usr/src/MonaServer2/MonaBase
 RUN make 
 WORKDIR /usr/src/MonaServer2/MonaCore


### PR DESCRIPTION
- Update LuaJIT version from 2.1.0-beta3 to 2.1.ROLLING
- Switch LuaJIT download source to official GitHub releases
- Update SHA256 checksum for the new archive
- Apply source patch to MonaServer2 replacing lseek64/off64_t with lseek/off_t to ensure compatibility with musl libc (Alpine Linux)

These changes allow the project to build successfully on Alpine-based containers where glibc-specific APIs like lseek64 and off64_t are not available.