### PR TITLE
Simplify and modernize the Docker build process for MonaServer2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,45 +3,44 @@
 
 FROM alpine:latest AS builder
 
-LABEL maintainer="Thomas Jammet <contact@monaserver.ovh>"
+ARG ENABLE_SRT=0
 
-ENV LUAJIT_VERSION 2.1.ROLLING
-ENV LUAJIT_DOWNLOAD_SHA256 31d7a4853df4c548bf91c13d3b690d19663d4c06ae952b62606c8225d0b410ad
+LABEL maintainer="Thomas Jammet <contact@monaserver.ovh>"
 
 # install prerequisites
 RUN apk add --no-cache libgcc \
 		libstdc++ \
-		openssl-dev
+		luajit \
+		libsrt
 
+# install build dependencies
 RUN apk add --no-cache --virtual .build-deps \
 		curl \
 		make \
 		g++ \
-		git
+		git \
+		openssl-dev \
+		luajit-dev \
+		libsrt-dev
 
-# Build & install luajit
 WORKDIR /usr/src
-RUN curl -fSL -o luajit.tar.gz https://github.com/LuaJIT/LuaJIT/archive/refs/tags/v$LUAJIT_VERSION.tar.gz \
-	&& echo "$LUAJIT_DOWNLOAD_SHA256 *luajit.tar.gz" | sha256sum -c \
-	&& tar -xzf luajit.tar.gz \
-	&& cd LuaJIT-$LUAJIT_VERSION \
-	&& sed -i 's/#XCFLAGS+= -DLUAJIT_ENABLE_LUA52COMPAT/XCFLAGS+= -DLUAJIT_ENABLE_LUA52COMPAT/g' src/Makefile \
-	&& make \
-	&& make install
 
-# Build
+# clone source
 RUN git clone https://github.com/MonaSolutions/MonaServer2.git
+# fix musl compatibility
 RUN find MonaServer2 -type f \( -name "*.cpp" -o -name "*.h" \) -exec sed -i 's/lseek64/lseek/g; s/off64_t/off_t/g' {} +
-WORKDIR /usr/src/MonaServer2/MonaBase
-RUN make 
-WORKDIR /usr/src/MonaServer2/MonaCore
-RUN make
-WORKDIR /usr/src/MonaServer2/MonaServer
-RUN make
+
+# build
+WORKDIR /usr/src/MonaServer2
+RUN make ENABLE_SRT=$ENABLE_SRT
 
 # install MonaServer
-RUN cp ../MonaBase/lib/libMonaBase.so ../MonaCore/lib/libMonaCore.so /usr/local/lib \
-	&& cp MonaServer ../MonaTiny/cert.pem ../MonaTiny/key.pem /usr/local/bin
+RUN install -Dm755 MonaServer/MonaServer /usr/local/bin/MonaServer \
+		&& install -Dm755 MonaTiny/MonaTiny /usr/local/bin/MonaTiny \
+		&& install -Dm644 MonaTiny/cert.pem /usr/local/bin/cert.pem \
+		&& install -Dm644 MonaTiny/key.pem /usr/local/bin/key.pem \
+		&& install -Dm755 MonaBase/lib/libMonaBase.so /usr/local/lib/libMonaBase.so \
+		&& install -Dm755 MonaCore/lib/libMonaCore.so /usr/local/lib/libMonaCore.so
 
 # No need to delete build tools with the multi-stage build
 
@@ -49,7 +48,10 @@ RUN cp ../MonaBase/lib/libMonaBase.so ../MonaCore/lib/libMonaCore.so /usr/local/
 # Create a new Docker image with just the binaries
 FROM alpine:latest
 
-RUN apk add --no-cache libgcc libstdc++
+RUN apk add --no-cache libgcc \
+		libstdc++ \
+		luajit \
+		libsrt
 
 COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /usr/local/bin /usr/local/bin
@@ -66,9 +68,10 @@ EXPOSE 1935/tcp
 EXPOSE 1935/udp
 # STUN
 EXPOSE 3478/udp
+# SRT
+EXPOSE 9710/udp
 
 WORKDIR /usr/local/bin
 
 # Set MonaServer as default executable
 CMD ["./MonaServer", "--log=7"]
-

--- a/README.md
+++ b/README.md
@@ -51,3 +51,19 @@ In this case it is possible to watch the logs in the *MonaServer.log/* directory
 ```
 docker exec mona tail -f /usr/local/bin/MonaTiny.log/0.log
 ```
+
+### Build options
+
+SRT support can be enabled at build time using a build argument.
+
+Enable SRT:
+
+```
+docker build --build-arg ENABLE_SRT=1 -t monaserver .
+```
+
+Default build (SRT disabled):
+
+```
+docker build -t monaserver .
+```


### PR DESCRIPTION
Key changes:
- Use Alpine packages for LuaJIT instead of building LuaJIT from source
- Add optional SRT support controlled via the ENABLE_SRT build argument
- Install runtime dependencies (luajit, libsrt) via apk
- Add build dependencies (openssl-dev, luajit-dev, libsrt-dev) to the build stage
- Replace multiple component builds with a single `make ENABLE_SRT=$ENABLE_SRT`
- Replace `cp` with `install` for safer file installation
- Reduce Dockerfile complexity and improve build reproducibility
- Expose SRT port (9710/udp)
- Document build options in README

This change simplifies the Dockerfile, reduces build complexity, and allowsoptional SRT support without requiring manual modifications to the build.